### PR TITLE
arm64: dts: qcom: msm8916-samsung-e5: Fix accelerometer matrix

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
@@ -64,7 +64,7 @@
 	/delete-node/ accelerometer@10;
 	/delete-node/ magnetometer@12;
 
-	accelerometer@1d {
+	accelerometer: accelerometer@1d {
 		compatible = "st,lis2hh12";
 		reg = <0x1d>;
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e5.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e5.dts
@@ -73,6 +73,12 @@
 	};
 };
 
+&accelerometer {
+	mount-matrix = "-1", "0", "0",
+			"0", "1", "0",
+			"0", "0", "1";
+};
+
 &panel {
 	/* Actually samsung,ea8061v-ams497ee10 */
 	compatible = "samsung,ea8061v-ams497ee01";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e5.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e5.dts
@@ -47,6 +47,12 @@
 	};
 };
 
+&accelerometer {
+	mount-matrix = "-1", "0", "0",
+			"0", "1", "0",
+			"0", "0", "1";
+};
+
 &battery {
 	charge-term-current-microamp = <200000>;
 	constant-charge-current-max-microamp = <1500000>;
@@ -71,12 +77,6 @@
 		pinctrl-0 = <&ts_int_default>;
 		pinctrl-names = "default";
 	};
-};
-
-&accelerometer {
-	mount-matrix = "-1", "0", "0",
-			"0", "1", "0",
-			"0", "0", "1";
 };
 
 &panel {


### PR DESCRIPTION
Correct accelerometer matrix readings for Samsung Galaxy E5.